### PR TITLE
Check if input is number before converting to Integer

### DIFF
--- a/APP/nodegoat/CMS/classes/StoreTypeObjects.php
+++ b/APP/nodegoat/CMS/classes/StoreTypeObjects.php
@@ -5618,7 +5618,7 @@ class StoreTypeObjects {
 			return $num;
 		}
 		
-		return bcmul($num, static::VALUE_NUMERIC_MULTIPLIER);
+		return is_numeric($num) ? bcmul($num, static::VALUE_NUMERIC_MULTIPLIER) : '';
 	}
 	
 	public static function int2Numeric($int) {


### PR DESCRIPTION
Importing non-numeric values in a decimal field results in an error. This fix checks if the input is numeric and returns an empty string if not.